### PR TITLE
No need for NgComponentOutlet

### DIFF
--- a/src/app/components/dynamic/dynamic.component.ts
+++ b/src/app/components/dynamic/dynamic.component.ts
@@ -1,16 +1,15 @@
-import { CommonModule } from "@angular/common";
 import { Component } from "@angular/core";
 
 @Component({
 	selector: "dynamic",
 	standalone: true,
-	imports: [CommonModule],
+	imports: [],
 	templateUrl: "./dynamic.component.html",
 	styleUrl: "./dynamic.component.scss",
 })
 export class DynamicComponent {
 	async ngOnInit() {
-		const Highcharts = await import("highcharts");
+		const Highcharts = await import("highcharts").then(m => m.default);
 
 		Highcharts.chart("container", {
 			chart: {

--- a/src/app/components/dynamic/dynamic.component.ts
+++ b/src/app/components/dynamic/dynamic.component.ts
@@ -1,4 +1,5 @@
 import { Component } from "@angular/core";
+import type HighchartsESM from 'highcharts/es-modules/masters/highcharts.src';
 
 @Component({
 	selector: "dynamic",
@@ -9,7 +10,7 @@ import { Component } from "@angular/core";
 })
 export class DynamicComponent {
 	async ngOnInit() {
-		const Highcharts = await import("highcharts").then(m => m.default);
+		const Highcharts: typeof HighchartsESM = await import("highcharts/es-modules/masters/highcharts.src").then(m => m.default);
 
 		Highcharts.chart("container", {
 			chart: {

--- a/src/app/components/main/main.component.html
+++ b/src/app/components/main/main.component.html
@@ -1,5 +1,6 @@
-<button (click)="loadDynamicComponent()" [disabled]="dynamicComponent">
-    Load Dynamic Component
+<button (click)="showComponent=!showComponent" >
+  Load Dynamic Component
 </button>
-
-<ng-container *ngComponentOutlet="dynamicComponent"></ng-container>
+@if (showComponent) {
+  <dynamic/>
+}

--- a/src/app/components/main/main.component.ts
+++ b/src/app/components/main/main.component.ts
@@ -1,20 +1,13 @@
-import { Component } from "@angular/core";
-import { DynamicComponent } from "../dynamic/dynamic.component";
-import { NgComponentOutlet } from "@angular/common";
+import {Component} from "@angular/core";
+import {DynamicComponent} from "../dynamic/dynamic.component";
 
 @Component({
 	selector: "main",
 	standalone: true,
-	imports: [DynamicComponent, NgComponentOutlet],
+	imports: [DynamicComponent],
 	templateUrl: "./main.component.html",
 	styleUrl: "./main.component.scss",
 })
 export class MainComponent {
-	public dynamicComponent: { new (): DynamicComponent } | null = null;
-
-	public async loadDynamicComponent() {
-		const { DynamicComponent } = await import("../dynamic/dynamic.component");
-
-		this.dynamicComponent = DynamicComponent;
-	}
+  public showComponent = false;
 }


### PR DESCRIPTION
Instead of having two layers of lazy-loading, one for the component `DynamicComponent` via NgComponentOutlet, and one for Highcharts itself via `DynamicComponent.ngOnInit()`, we can have only one for Highcharts.

This is easier to use, since there is nothing special to do when using `DynamicComponent`, and we still benefit from lazy-loading Highcharts.

And the `@if` is not necessary to have lazy-loading in both dev build and production build. So it can be removed entirely.